### PR TITLE
Fix of spelling mistake in mongoose provider guide

### DIFF
--- a/docs/other/mongoose.md
+++ b/docs/other/mongoose.md
@@ -103,7 +103,7 @@ const guildSchema = new Schema({
     },
     settings: {
         type: Object,
-        require: true
+        required: true
     }
 }, { minimize: false });
 


### PR DESCRIPTION
Changing `require` to `required` as it's not a supported property of `SchemaType`