### PR TITLE
Fixed client voice channel not found error

### DIFF
--- a/src/struct/commands/CommandHandler.js
+++ b/src/struct/commands/CommandHandler.js
@@ -658,7 +658,7 @@ class CommandHandler extends AkairoHandler {
                     return true;
                 }
             } else if (message.guild) {
-                const missing = message.member.voice ? message.member.voice.channel.permissionsFor(this.client.user).missing(command.clientPermissions) : message.channel.permissionsFor(this.client.user).missing(command.clientPermissions);
+                const missing = message.member.voice.channelID ? message.member.voice.channel.permissionsFor(this.client.user).missing(command.clientPermissions) : message.channel.permissionsFor(this.client.user).missing(command.clientPermissions);
                 if (missing.length) {
                     this.emit(CommandHandlerEvents.MISSING_PERMISSIONS, message, command, 'client', missing);
                     return true;


### PR DESCRIPTION
Fixed this bug

```ts
TypeError: Cannot read property 'permissionsFor' of null
    at CommandHandler.runPermissionChecks (Owo\node_modules\@auric\discord-akairo\src\struct\commands\CommandHandler.js:661:85)
    at CommandHandler.runPostTypeInhibitors (Owo\node_modules\@auric\discord-akairo\src\struct\commands\CommandHandler.js:624:24)
    at CommandHandler.handleDirectCommand (Owo\node_modules\@auric\discord-akairo\src\struct\commands\CommandHandler.js:407:32)
    at CommandHandler.handle (Owo\node_modules\@auric\discord-akairo\src\struct\commands\CommandHandler.js:379:34)
```